### PR TITLE
use older machina version

### DIFF
--- a/component.json
+++ b/component.json
@@ -8,7 +8,7 @@
     "component/trim": "*",
     "component/type": "*",
     "dominicbarnes/wrap": "*",
-    "ifandelse/machina.js": "master",
+    "ifandelse/machina.js": "v0.3.8",
     "matthewp/text": "*",
     "yields/empty": "*"
   },


### PR DESCRIPTION
The newest machina update breaks inlineedit (also affects inlineedit-multiline and inlineedit-select).
